### PR TITLE
docs: fix problem heading typo

### DIFF
--- a/recipes/mailbox/enable-autoexpanding-archive.md
+++ b/recipes/mailbox/enable-autoexpanding-archive.md
@@ -1,6 +1,6 @@
 # Enable AutoExpanding Archive On A Mailbox
 
-## Probken
+## Problem
 
 You want to enable AutoExpanding Archive on an individual user's mailbox
 


### PR DESCRIPTION
## Summary
- correct a heading typo in the autoexpanding archive recipe

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_685086aea17c8322b736a1c315facc55